### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -255,7 +255,7 @@ workflow steps and expected outputs:
       type: serial
       specification:
         steps:
-          - environment: 'reanahub/reana-env-root6'
+          - environment: 'docker.io/reanahub/reana-env-root6'
             commands:
             - mkdir -p results/tmp && mkdir -p logs
             - root -b -q 'Optimise.C("${data}", "results")' | tee logs/optimise.log

--- a/reana.yaml
+++ b/reana.yaml
@@ -13,7 +13,7 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'reanahub/reana-env-root6'
+      - environment: 'docker.io/reanahub/reana-env-root6'
         commands:
         - mkdir -p results/tmp && mkdir -p logs
         - root -b -q 'Optimise.C("${data}", "results")' | tee logs/optimise.log

--- a/workflow/cwl/mass_fit.cwl
+++ b/workflow/cwl/mass_fit.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 requirements:
   DockerRequirement:
     dockerPull:
-      reanahub/reana-env-root6
+      docker.io/reanahub/reana-env-root6
   InitialWorkDirRequirement:
     listing:
       - $(inputs.mass_fit_tool)

--- a/workflow/cwl/model_fixing.cwl
+++ b/workflow/cwl/model_fixing.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 requirements:
   DockerRequirement:
     dockerPull:
-      reanahub/reana-env-root6
+      docker.io/reanahub/reana-env-root6
   InitialWorkDirRequirement:
     listing:
       - $(inputs.model_fixing_tool)

--- a/workflow/cwl/optimise.cwl
+++ b/workflow/cwl/optimise.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 requirements:
   DockerRequirement:
     dockerPull:
-      reanahub/reana-env-root6
+      docker.io/reanahub/reana-env-root6
   InitialWorkDirRequirement:
     listing:
       - $(inputs.optimise_tool)

--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -35,7 +35,7 @@ stages:
             plot_mumumass: out_plot_mumumass
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-root6'
+          image: 'docker.io/reanahub/reana-env-root6'
 
   - name: theoreticalmodelfixing
     dependencies: [optimisation]
@@ -55,7 +55,7 @@ stages:
             phimodels: outfilename
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-root6'
+          image: 'docker.io/reanahub/reana-env-root6'
 
   - name: massfitting
     dependencies: [theoreticalmodelfixing]
@@ -86,4 +86,4 @@ stages:
             plot_phi: out_plot_phi
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-root6'
+          image: 'docker.io/reanahub/reana-env-root6'


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.