### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,20 @@ name: ci
 on: [push, pull_request]
 
 jobs:
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,18 @@ name: ci
 on: [push, pull_request]
 
 jobs:
+
+format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2023, 2024, 2026 CERN.
+# Copyright (C) 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,8 +9,7 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-
-format-shfmt:
+  format-shfmt:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -47,6 +46,20 @@ format-shfmt:
         run: |
           ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-shellcheck:
     runs-on: ubuntu-24.04
     steps:
@@ -58,13 +71,11 @@ format-shfmt:
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
 
-lint-yamllint:
+  lint-yamllint:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,21 @@ jobs:
         run: |
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
+
+lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on: [push, pull_request]
 
@@ -28,12 +28,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-24.04
@@ -44,4 +44,4 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+          ./run-tests.sh --lint-shellcheck

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,7 @@
-# Allow long lines (to be fixed when prettier is added)
-MD013: false
+# Allow long lines in code blocks and tables
+MD013:
+  code_blocks: false
+  tables: false
 # Allow prompt dollar sign in console examples without showing output
 MD014: false
 # Allow flexible list spacing

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+# Allow long lines (to be fixed when prettier is added)
+MD013: false
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+# Allow flexible list spacing
+MD032: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,8 @@
 extends: default
 
 rules:
+  braces:
+    max-spaces-inside: 1
   comments:
     min-spaces-from-content: 1
   document-start: disable

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
 This analysis example attempts to reproduce
 [LHCb rare charm decay study](https://cds.cern.ch/record/1543929) published in
-[Phys. Lett. B 724 (2013)
-203-212](https://www.sciencedirect.com/science/article/pii/S0370269313004747?via%3Dihub).
+[Phys. Lett. B 724 (2013) 203-212](https://www.sciencedirect.com/science/article/pii/S0370269313004747?via%3Dihub).
 
 ![image](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/decay.png)
 
@@ -55,7 +54,7 @@ Headers and Plot style:
 - [lhcbStyle.C](lhcbStyle.C) - Plot formats specific to the LHCb collaboration.
 
 - [RooFitHeaders.h](RooFitHeaders.h) - Libraries and packages needed to perform
-the fitting.
+  the fitting.
 
 #### Step 1: Optimisation stage [Optimise.C](Optimise.C)
 
@@ -170,12 +169,16 @@ The result of this analysis are the following plots in various dimuon mass
 ranges. We studied the three body decay in high dimuon and low dimuon mass
 range, and we did not observe any signal.
 
-| Dimuon resonances | Dimuon mass range (MeV) | Plot | |
------------------------------ | ----------------------- |
------------------------- | | Three body decay (low dimuon) | 250 - 525 |
-`low_dimuon_signal.pdf` | | $\eta$ | 525 - 565 | `eta.pdf` | | $\rho , \omega$ |
-565 - 850 | `rho_omega.pdf` | | $\phi$ | 850 - 1250 | `phi.pdf` | | Three body
-(high dimuon) | 1250 - 2000 | `high_dimuon_signal.pdf` |
+<!-- markdownlint-disable MD013 -->
+
+| Dimuon resonances        | Dimuon mass range (MeV) | Plot                          |           |
+| ------------------------ | ----------------------- | ----------------------------- | --------- | ---------- | --------- | --------------- | ---------- |
+| ------------------------ |                         | Three body decay (low dimuon) | 250 - 525 |
+| `low_dimuon_signal.pdf`  |                         | $\eta$                        | 525 - 565 | `eta.pdf`  |           | $\rho , \omega$ |
+| 565 - 850                | `rho_omega.pdf`         |                               | $\phi$    | 850 - 1250 | `phi.pdf` |                 | Three body |
+| (high dimuon)            | 1250 - 2000             | `high_dimuon_signal.pdf`      |
+
+<!-- markdownlint-enable MD013 -->
 
 The plots can be found in the `mass_fits` folder at the end of the execution.
 
@@ -213,12 +216,15 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'docker.io/reanahub/reana-env-root6'
+      - environment: "docker.io/reanahub/reana-env-root6"
         commands:
-        - mkdir -p results/tmp && mkdir -p logs
-        - root -b -q 'Optimise.C("${data}", "results")' | tee logs/optimise.log
-        - root -b -q 'ModelFixing.C("${data}", "results/tmp/PhiModels.root")' | tee logs/model_fixing.log
-        - root -b -q 'OSMassFit.C("${data}", "results/tmp/PhiModels.root", "results")'  | tee logs/massfit.log
+          - mkdir -p results/tmp && mkdir -p logs
+          - root -b -q 'Optimise.C("${data}", "results")' | tee
+            logs/optimise.log
+          - root -b -q 'ModelFixing.C("${data}", "results/tmp/PhiModels.root")'
+            | tee logs/model_fixing.log
+          - root -b -q 'OSMassFit.C("${data}", "results/tmp/PhiModels.root",
+            "results")'  | tee logs/massfit.log
 outputs:
   files:
     - results/2D_Optimisation_Pi.pdf

--- a/README.md
+++ b/README.md
@@ -7,16 +7,17 @@
 
 This analysis example attempts to reproduce
 [LHCb rare charm decay study](https://cds.cern.ch/record/1543929) published in
-[Phys. Lett. B 724 (2013) 203-212](https://www.sciencedirect.com/science/article/pii/S0370269313004747?via%3Dihub).
+[Phys. Lett. B 724 (2013)
+203-212](https://www.sciencedirect.com/science/article/pii/S0370269313004747?via%3Dihub).
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/decay.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/decay.png)
 
-These decays are very rare, which makes their observation extremely challenging. The LHC
-produces a lot of charm particles $D$, but it also produces a much greater number of
-other particles which can be mistaken for the signal. It is necessary to develop an
-effective strategy to identify the signal events in the large data sample. The event
-selection strategy is implemented in three stages: the trigger selection, stripping
-selection and the multivariate analysis.
+These decays are very rare, which makes their observation extremely challenging.
+The LHC produces a lot of charm particles $D$, but it also produces a much
+greater number of other particles which can be mistaken for the signal. It is
+necessary to develop an effective strategy to identify the signal events in the
+large data sample. The event selection strategy is implemented in three stages:
+the trigger selection, stripping selection and the multivariate analysis.
 
 In the [paper](https://cds.cern.ch/record/1543929), you can lean more about the
 theoretical background and motivation to study this decay.
@@ -26,17 +27,17 @@ This example is based on this
 
 ## Analysis structure
 
-Making a research data analysis reproducible basically means to provide "runnable
-recipes" addressing (1) where is the input data, (2) what software was used to analyse
-the data, (3) which computing environments were used to run the software and (4) which
-computational workflow steps were taken to run the analysis. This will permit to
-instantiate the analysis on the computational cloud and run the analysis to obtain (5)
-output results.
+Making a research data analysis reproducible basically means to provide
+"runnable recipes" addressing (1) where is the input data, (2) what software was
+used to analyse the data, (3) which computing environments were used to run the
+software and (4) which computational workflow steps were taken to run the
+analysis. This will permit to instantiate the analysis on the computational
+cloud and run the analysis to obtain (5) output results.
 
 ### 1. Input data
 
-The data being used is currently only available on request. It consists of a 10 GB ROOT
-file.
+The data being used is currently only available on request. It consists of a 10
+GB ROOT file.
 
 ### 2. Analysis code
 
@@ -53,18 +54,19 @@ Headers and Plot style:
 
 - [lhcbStyle.C](lhcbStyle.C) - Plot formats specific to the LHCb collaboration.
 
-- [RooFitHeaders.h](RooFitHeaders.h) - Libraries and packages needed to perform the
-  fitting.
+- [RooFitHeaders.h](RooFitHeaders.h) - Libraries and packages needed to perform
+the fitting.
 
 #### Step 1: Optimisation stage [Optimise.C](Optimise.C)
 
-Optimisation is the process where combinations of different variable cuts are evaluated
-in order to maximise the signal yield and reduce the background. In this analysis, the
-optimisation study is performed to choose the combined BDT and particle identification
-(PID) selection criteria that maximise the expected statistical significance. The result
-of the script is the heat map called `2D_Optimisation_Pi.pdf`. The higher significance
-(in yellow) means cleaner signal. The optimal significance is found to be at the cuts of
-`BDT > 0.1` and `PIDmu > 2`.
+Optimisation is the process where combinations of different variable cuts are
+evaluated in order to maximise the signal yield and reduce the background. In
+this analysis, the optimisation study is performed to choose the combined BDT
+and particle identification (PID) selection criteria that maximise the expected
+statistical significance. The result of the script is the heat map called
+`2D_Optimisation_Pi.pdf`. The higher significance (in yellow) means cleaner
+signal. The optimal significance is found to be at the cuts of `BDT > 0.1` and
+`PIDmu > 2`.
 
 ```console
 $ root -b -q Optimisation.C(<data_file>, <results_directory>)
@@ -80,9 +82,9 @@ $ root -b -q ModelFixing.C(<data_file>, <tmp_phi_models>)
 
 #### Step 3: Mass Fitting stage [OSMassFit.C](OSMassFit.C)
 
-The fit for the signal was modelled with the sum of Crystal Ball distributions. Each
-shape consists of a Gaussian core with a power law tail on opposite sides. The background
-was modelled with a 2nd order Chebyshev polynomial distribution.
+The fit for the signal was modelled with the sum of Crystal Ball distributions.
+Each shape consists of a Gaussian core with a power law tail on opposite sides.
+The background was modelled with a 2nd order Chebyshev polynomial distribution.
 
 ```console
 $ root -b -q OSMassFit.C(<data_file>, <tmp_phi_models>,  <results_directory>)
@@ -90,19 +92,20 @@ $ root -b -q OSMassFit.C(<data_file>, <tmp_phi_models>,  <results_directory>)
 
 ### 3. Compute environment
 
-In order to be able to rerun the analysis even several years in the future, we need to
-"encapsulate the current compute environment", for example to freeze the ROOT version our
-analysis is using. We shall achieve this by preparing a [Docker](https://www.docker.com/)
-container image for our analysis steps.
+In order to be able to rerun the analysis even several years in the future, we
+need to "encapsulate the current compute environment", for example to freeze the
+ROOT version our analysis is using. We shall achieve this by preparing a
+[Docker](https://www.docker.com/) container image for our analysis steps.
 
-Some of the analysis steps will run in a pure [ROOT](https://root.cern.ch/) analysis
-environment. We can use an already existing container image, for example
-[reana-env-root6](https://github.com/reanahub/reana-env-root6), for these steps.
+Some of the analysis steps will run in a pure [ROOT](https://root.cern.ch/)
+analysis environment. We can use an already existing container image, for
+example [reana-env-root6](https://github.com/reanahub/reana-env-root6), for
+these steps.
 
 ### 4. Analysis workflow
 
-This analysis example consists of a simple workflow the theoretical model is generated
-and used for fitting.
+This analysis example consists of a simple workflow the theoretical model is
+generated and used for fitting.
 
 The analysis workflow consists of the above mentioned stages:
 
@@ -163,37 +166,36 @@ Note that you can also use [CWL](http://www.commonwl.org/v1.0/) or
 
 ### 5. Output results - Mass fit
 
-The result of this analysis are the following plots in various dimuon mass ranges. We
-studied the three body decay in high dimuon and low dimuon mass range, and we did not
-observe any signal.
+The result of this analysis are the following plots in various dimuon mass
+ranges. We studied the three body decay in high dimuon and low dimuon mass
+range, and we did not observe any signal.
 
-| Dimuon resonances             | Dimuon mass range (MeV) | Plot                     |
-| ----------------------------- | ----------------------- | ------------------------ |
-| Three body decay (low dimuon) | 250 - 525               | `low_dimuon_signal.pdf`  |
-| $\eta$                        | 525 - 565               | `eta.pdf`                |
-| $\rho , \omega$               | 565 - 850               | `rho_omega.pdf`          |
-| $\phi$                        | 850 - 1250              | `phi.pdf`                |
-| Three body (high dimuon)      | 1250 - 2000             | `high_dimuon_signal.pdf` |
+| Dimuon resonances | Dimuon mass range (MeV) | Plot | |
+----------------------------- | ----------------------- |
+------------------------ | | Three body decay (low dimuon) | 250 - 525 |
+`low_dimuon_signal.pdf` | | $\eta$ | 525 - 565 | `eta.pdf` | | $\rho , \omega$ |
+565 - 850 | `rho_omega.pdf` | | $\phi$ | 850 - 1250 | `phi.pdf` | | Three body
+(high dimuon) | 1250 - 2000 | `high_dimuon_signal.pdf` |
 
 The plots can be found in the `mass_fits` folder at the end of the execution.
 
 One of the final plots, representing the $\phi$ contribution, is shown below.
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/phi.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/phi.png)
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/eta.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/eta.png)
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/high_dimuon_signal.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/high_dimuon_signal.png)
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/low_dimuon_signal.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/low_dimuon_signal.png)
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/rho_omega.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-lhcb-d2pimumu/master/docs/rho_omega.png)
 
 ## Running the example on REANA cloud
 
-We start by creating a [reana.yaml](reana.yaml) file describing the above analysis
-structure with its inputs, code, runtime environment, computational workflow steps and
-expected outputs:
+We start by creating a [reana.yaml](reana.yaml) file describing the above
+analysis structure with its inputs, code, runtime environment, computational
+workflow steps and expected outputs:
 
 ```yaml
 version: 0.6.0
@@ -228,8 +230,8 @@ outputs:
     - results/phi.pdf
 ```
 
-We can now install the REANA command-line client, run the analysis and download the
-resulting plots:
+We can now install the REANA command-line client, run the analysis and download
+the resulting plots:
 
 ```console
 $ # create new virtual environment
@@ -255,5 +257,6 @@ $ # download generated plots
 $ reana-client download
 ```
 
-Please see the [REANA-Client](https://reana-client.readthedocs.io/) documentation for
-more detailed explanation of typical `reana-client` usage scenarios.
+Please see the [REANA-Client](https://reana-client.readthedocs.io/)
+documentation for more detailed explanation of typical `reana-client` usage
+scenarios.

--- a/reana.yaml
+++ b/reana.yaml
@@ -13,12 +13,15 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'docker.io/reanahub/reana-env-root6'
+      - environment: "docker.io/reanahub/reana-env-root6"
         commands:
-        - mkdir -p results/tmp && mkdir -p logs
-        - root -b -q 'Optimise.C("${data}", "results")' | tee logs/optimise.log
-        - root -b -q 'ModelFixing.C("${data}", "results/tmp/PhiModels.root")' | tee logs/model_fixing.log
-        - root -b -q 'OSMassFit.C("${data}", "results/tmp/PhiModels.root", "results")'  | tee logs/massfit.log
+          - mkdir -p results/tmp && mkdir -p logs
+          - root -b -q 'Optimise.C("${data}", "results")' | tee
+            logs/optimise.log
+          - root -b -q 'ModelFixing.C("${data}", "results/tmp/PhiModels.root")'
+            | tee logs/model_fixing.log
+          - root -b -q 'OSMassFit.C("${data}", "results/tmp/PhiModels.root",
+            "results")'  | tee logs/massfit.log
 outputs:
   files:
     - results/2D_Optimisation_Pi.pdf

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -47,6 +47,10 @@ lint_commitlint() {
     fi
 }
 
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
@@ -58,6 +62,7 @@ lint_yamllint() {
 all() {
     format_shfmt
     lint_commitlint
+    lint_markdownlint
     lint_shellcheck
     lint_yamllint
 }
@@ -65,12 +70,13 @@ all() {
 help() {
     echo "Usage: $0 [options]"
     echo "Options:"
-    echo "  --all              Perform all checks [default]"
-    echo "  --format-shfmt     Check formatting of shell scripts"
-    echo "  --help             Display this help message"
-    echo "  --lint-commitlint  Check linting of commit messages"
-    echo "  --lint-shellcheck  Check linting of shell scripts"
-    echo "  --lint-yamllint    Check linting of YAML files"
+    echo "  --all                Perform all checks [default]"
+    echo "  --format-shfmt       Check formatting of shell scripts"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -84,6 +90,7 @@ case $arg in
 --help) help ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_shfmt() {
+    shfmt -d .
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
@@ -31,7 +35,7 @@ lint_commitlint() {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -52,6 +56,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_shfmt
     lint_commitlint
     lint_shellcheck
     lint_yamllint
@@ -61,6 +66,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all              Perform all checks [default]"
+    echo "  --format-shfmt     Check formatting of shell scripts"
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
@@ -76,6 +82,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -47,9 +47,14 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 all() {
     lint_commitlint
     lint_shellcheck
+    lint_yamllint
 }
 
 help() {
@@ -59,6 +64,7 @@ help() {
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
+    echo "  --lint-yamllint    Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -72,5 +78,6 @@ case $arg in
 --help) help ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_prettier() {
+    prettier -c .
+}
+
 format_shfmt() {
     shfmt -d .
 }
@@ -60,6 +64,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_prettier
     format_shfmt
     lint_commitlint
     lint_markdownlint
@@ -71,6 +76,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all                Perform all checks [default]"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
     echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -88,6 +94,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-prettier) format_prettier ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-markdownlint) lint_markdownlint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,7 +9,7 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
@@ -43,23 +43,34 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
+all() {
+    lint_commitlint
+    lint_shellcheck
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all              Perform all checks [default]"
+    echo "  --help             Display this help message"
+    echo "  --lint-commitlint  Check linting of commit messages"
+    echo "  --lint-shellcheck  Check linting of shell scripts"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-shellcheck) lint_shellcheck ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -17,67 +17,69 @@ stages:
   - name: optimisation
     dependencies: [init]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        optimise: {stages: init, output: optimise, unwrap: true}
-        data: {stages: init, output: data, unwrap: true}
-        outfilepath: '{workdir}'
-        out_plot_2d_optimisation: '{workdir}/2D_Optimisation_Pi.pdf'
-        out_plot_mumumass: '{workdir}/MuMuMass_Pi.pdf'
+        optimise: { stages: init, output: optimise, unwrap: true }
+        data: { stages: init, output: data, unwrap: true }
+        outfilepath: "{workdir}"
+        out_plot_2d_optimisation: "{workdir}/2D_Optimisation_Pi.pdf"
+        out_plot_mumumass: "{workdir}/MuMuMass_Pi.pdf"
       step:
         process:
-          process_type: 'interpolated-script-cmd'
+          process_type: "interpolated-script-cmd"
           script: root -b -q '{optimise}("{data}", "{outfilepath}")'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             plot_2d_optimisation: out_plot_2d_optimisation
             plot_mumumass: out_plot_mumumass
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/reanahub/reana-env-root6'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/reanahub/reana-env-root6"
 
   - name: theoreticalmodelfixing
     dependencies: [optimisation]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        modelfixing: {stages: init, output: modelfixing, unwrap: true}
-        data: {stages: init, output: data, unwrap: true}
-        outfilename: '{workdir}/PhiModels.root'
+        modelfixing: { stages: init, output: modelfixing, unwrap: true }
+        data: { stages: init, output: data, unwrap: true }
+        outfilename: "{workdir}/PhiModels.root"
       step:
         process:
-          process_type: 'interpolated-script-cmd'
+          process_type: "interpolated-script-cmd"
           script: root -b -q '{modelfixing}("{data}", "{outfilename}")'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             phimodels: outfilename
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/reanahub/reana-env-root6'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/reanahub/reana-env-root6"
 
   - name: massfitting
     dependencies: [theoreticalmodelfixing]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        massfit: {stages: init, output: massfit, unwrap: true}
-        data: {stages: init, output: data, unwrap: true}
-        phimodels: {stages: theoreticalmodelfixing, output: phimodels, unwrap: true}
-        outfilepath: '{workdir}'
-        out_plot_low_dimuon_signal: '{workdir}/low_dimuon_signal.pdf'
-        out_plot_high_dimuon_signal: '{workdir}/high_dimuon_signal.pdf'
-        out_plot_eta: '{workdir}/eta.pdf'
-        out_plot_rho_omega: '{workdir}/rho_omega.pdf'
-        out_plot_phi: '{workdir}/phi.pdf'
+        massfit: { stages: init, output: massfit, unwrap: true }
+        data: { stages: init, output: data, unwrap: true }
+        phimodels:
+          { stages: theoreticalmodelfixing, output: phimodels, unwrap: true }
+        outfilepath: "{workdir}"
+        out_plot_low_dimuon_signal: "{workdir}/low_dimuon_signal.pdf"
+        out_plot_high_dimuon_signal: "{workdir}/high_dimuon_signal.pdf"
+        out_plot_eta: "{workdir}/eta.pdf"
+        out_plot_rho_omega: "{workdir}/rho_omega.pdf"
+        out_plot_phi: "{workdir}/phi.pdf"
 
       step:
         process:
-          process_type: 'interpolated-script-cmd'
-          script: root -b -q '{massfit}("{data}", "{phimodels}", "{outfilepath}")'
+          process_type: "interpolated-script-cmd"
+          script:
+            root -b -q '{massfit}("{data}", "{phimodels}", "{outfilepath}")'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             plot_low_dimuon_signal: out_plot_low_dimuon_signal
             plot_high_dimuon_signal: out_plot_high_dimuon_signal
@@ -85,5 +87,5 @@ stages:
             plot_rho_omega: out_plot_rho_omega
             plot_phi: out_plot_phi
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/reanahub/reana-env-root6'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/reanahub/reana-env-root6"


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.